### PR TITLE
Assurance / Audit registry contract + hardhat tests

### DIFF
--- a/contracts/audit/AuditRegistry.sol
+++ b/contracts/audit/AuditRegistry.sol
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.24;
+
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "../erc721/ERC721Metadata.sol";
+
+/**
+ * @title AuditRegistry
+ * @author Hashgraph
+ * @notice This contract manages audit records for building NFTs.
+ */
+contract AuditRegistry is AccessControl {
+    bytes32 public constant AUDITOR_ROLE = keccak256("AUDITOR_ROLE");
+
+    struct AuditRecord {
+        uint256 buildingId;      // ID of the building NFT
+        address auditor;         // Address of the auditor
+        string ipfsHash;         // IPFS hash of the audit document
+        uint256 timestamp;       // Timestamp when the audit was added
+        bool revoked;            // Status of the audit record
+    }
+
+    mapping(uint256 => AuditRecord) public auditRecords;
+    mapping(uint256 => uint256[]) public buildingAuditRecords;
+    uint256 public auditRecordCounter = 0;
+    ERC721Metadata public buildingNFT;
+
+    event AuditRecordAdded(
+        uint256 indexed auditRecordId,
+        uint256 indexed buildingId,
+        address indexed auditor,
+        string ipfsHash,
+        uint256 timestamp
+    );
+    event AuditRecordUpdated(
+        uint256 indexed auditRecordId,
+        string newIpfsHash,
+        uint256 timestamp
+    );
+    event AuditRecordRevoked(
+        uint256 indexed auditRecordId,
+        uint256 timestamp
+    );
+    event AuditorAdded(address indexed auditor);
+    event AuditorRemoved(address indexed auditor);
+
+    /**
+     * @dev Constructor sets the ERC721Metadata contract address and grants admin role.
+     * @param _buildingNFTAddress Address of the ERC721Metadata contract
+     */
+    constructor(address _buildingNFTAddress) {
+        require(_buildingNFTAddress != address(0), "Invalid NFT contract address");
+        buildingNFT = ERC721Metadata(_buildingNFTAddress);
+        grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    }
+
+    modifier buildingExists(uint256 _buildingId) {
+        require(_exists(_buildingId), "AuditRegistry: Building does not exist");
+        _;
+    }
+
+    function _exists(uint256 tokenId) internal view returns (bool) {
+        return buildingNFT.ownerOf(tokenId) != address(0);
+    }
+
+    function addAuditor(address _auditor) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(_auditor != address(0), "AuditRegistry: Invalid auditor address");
+        grantRole(AUDITOR_ROLE, _auditor);
+        emit AuditorAdded(_auditor);
+    }
+
+    function removeAuditor(address _auditor) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        revokeRole(AUDITOR_ROLE, _auditor);
+        emit AuditorRemoved(_auditor);
+    }
+
+    /**
+     * @notice Adds a new audit record for a building.
+     * @param _buildingId The ID of the building NFT.
+     * @param _ipfsHash The IPFS hash of the audit document.
+     */
+    function addAuditRecord(uint256 _buildingId, string calldata _ipfsHash)
+        external
+        onlyRole(AUDITOR_ROLE)
+        buildingExists(_buildingId)
+    {
+        require(bytes(_ipfsHash).length > 0, "AuditRegistry: IPFS hash is required");
+
+        auditRecordCounter++;
+        auditRecords[auditRecordCounter] = AuditRecord({
+            buildingId: _buildingId,
+            auditor: msg.sender,
+            ipfsHash: _ipfsHash,
+            timestamp: block.timestamp,
+            revoked: false
+        });
+        buildingAuditRecords[_buildingId].push(auditRecordCounter);
+
+        emit AuditRecordAdded(
+            auditRecordCounter,
+            _buildingId,
+            msg.sender,
+            _ipfsHash,
+            block.timestamp
+        );
+    }
+
+    /**
+     * @notice Updates an existing audit record.
+     * @param _auditRecordId The ID of the audit record to update.
+     * @param _newIpfsHash The new IPFS hash of the audit document.
+     */
+    function updateAuditRecord(uint256 _auditRecordId, string calldata _newIpfsHash)
+        external
+        onlyRole(AUDITOR_ROLE)
+    {
+        require(bytes(_newIpfsHash).length > 0, "AuditRegistry: IPFS hash is required");
+        AuditRecord storage record = auditRecords[_auditRecordId];
+        require(record.auditor == msg.sender, "AuditRegistry: Not the original auditor");
+        require(!record.revoked, "AuditRegistry: Cannot update a revoked record");
+
+        record.ipfsHash = _newIpfsHash;
+        record.timestamp = block.timestamp;
+
+        emit AuditRecordUpdated(_auditRecordId, _newIpfsHash, block.timestamp);
+    }
+
+    /**
+     * @notice Revokes an audit record.
+     * @param _auditRecordId The ID of the audit record to revoke.
+     */
+    function revokeAuditRecord(uint256 _auditRecordId) external onlyRole(AUDITOR_ROLE) {
+        AuditRecord storage record = auditRecords[_auditRecordId];
+        require(record.auditor == msg.sender, "AuditRegistry: Not the original auditor");
+        require(!record.revoked, "AuditRegistry: Record already revoked");
+
+        record.revoked = true;
+
+        emit AuditRecordRevoked(_auditRecordId, block.timestamp);
+    }
+
+    /**
+     * @notice Retrieves audit records for a specific building.
+     * @param _buildingId The ID of the building NFT.
+     * @return An array of audit record IDs.
+     */
+    function getAuditRecordsByBuilding(uint256 _buildingId)
+        external
+        view
+        returns (uint256[] memory)
+    {
+        return buildingAuditRecords[_buildingId];
+    }
+
+    /**
+     * @notice Retrieves details of a specific audit record.
+     * @param _auditRecordId The ID of the audit record.
+     * @return The AuditRecord struct containing audit details.
+     */
+    function getAuditRecordDetails(uint256 _auditRecordId)
+        external
+        view
+        returns (AuditRecord memory)
+    {
+        return auditRecords[_auditRecordId];
+    }
+}

--- a/contracts/audit/AuditRegistry.sol
+++ b/contracts/audit/AuditRegistry.sol
@@ -6,18 +6,18 @@ import "../erc721/ERC721Metadata.sol";
 
 /**
  * @title AuditRegistry
- * @author Hashgraph
+ * @author
  * @notice This contract manages audit records for building NFTs.
  */
 contract AuditRegistry is AccessControl {
     bytes32 public constant AUDITOR_ROLE = keccak256("AUDITOR_ROLE");
 
     struct AuditRecord {
-        uint256 buildingId;      // ID of the building NFT
-        address auditor;         // Address of the auditor
-        string ipfsHash;         // IPFS hash of the audit document
-        uint256 timestamp;       // Timestamp when the audit was added
-        bool revoked;            // Status of the audit record
+        uint256 buildingId;   // ID of the building NFT
+        address auditor;      // Address of the auditor
+        string ipfsHash;      // IPFS hash of the audit document
+        uint256 timestamp;    // Timestamp when the audit was added
+        bool revoked;         // Status of the audit record
     }
 
     mapping(uint256 => AuditRecord) public auditRecords;
@@ -51,7 +51,7 @@ contract AuditRegistry is AccessControl {
     constructor(address _buildingNFTAddress) {
         require(_buildingNFTAddress != address(0), "Invalid NFT contract address");
         buildingNFT = ERC721Metadata(_buildingNFTAddress);
-        grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
+        _grantRole(DEFAULT_ADMIN_ROLE, msg.sender); // Use internal function to assign admin role
     }
 
     modifier buildingExists(uint256 _buildingId) {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -21,7 +21,7 @@ const config: HardhatUserConfig = {
       },
     },
   },
-  defaultNetwork: "testnet",
+  defaultNetwork: "hardhat",
   networks: {
     mainnet: {
       chainId: 295, // hedera mainnet chainId

--- a/test/audit/AuditRegistry.test.ts
+++ b/test/audit/AuditRegistry.test.ts
@@ -1,0 +1,86 @@
+import { expect, ethers } from '../setup';
+import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
+import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
+
+
+async function deployFixture() {
+  const [owner, auditor1, auditor2] = await ethers.getSigners();
+
+  const ERC721Metadata = await ethers.getContractFactory('ERC721Metadata', owner);
+  const erc721Metadata = await ERC721Metadata.deploy('BuildingNFT', 'BLD');
+  await erc721Metadata.waitForDeployment();
+
+  const AuditRegistry = await ethers.getContractFactory('AuditRegistry', owner);
+  const auditRegistry = await AuditRegistry.deploy(await erc721Metadata.getAddress());
+  await auditRegistry.waitForDeployment();
+
+  return {
+    owner,
+    auditor1,
+    auditor2,
+    erc721Metadata,
+    auditRegistry,
+  };
+}
+
+describe('AuditRegistry', () => {
+  describe('Deployment', () => {
+    it('should deploy contracts successfully', async () => {
+      const { erc721Metadata, auditRegistry } = await loadFixture(deployFixture);
+
+      expect(erc721Metadata.getAddress()).to.be.a('string');
+      expect(auditRegistry.getAddress()).to.be.a('string');
+    });
+  });
+
+  describe('Auditor Management', () => {
+    it('should allow the admin to add an auditor', async () => {
+      const { auditRegistry, auditor1, owner } = await loadFixture(deployFixture);
+
+      const AUDITOR_ROLE = await auditRegistry.AUDITOR_ROLE();
+
+      await auditRegistry.connect(owner).addAuditor(await auditor1.getAddress());
+
+      const hasRole = await auditRegistry.hasRole(AUDITOR_ROLE, await auditor1.getAddress());
+      expect(hasRole).to.be.true;
+    });
+
+    it('should not allow non-admin to add an auditor', async () => {
+      const { auditRegistry, auditor1, auditor2 } = await loadFixture(deployFixture);
+
+      const DEFAULT_ADMIN_ROLE = await auditRegistry.DEFAULT_ADMIN_ROLE();
+
+      await expect(
+        auditRegistry.connect(auditor1).addAuditor(await auditor2.getAddress())
+      ).to.be.revertedWith(`AccessControl: account ${await auditor1.getAddress()} is missing role ${DEFAULT_ADMIN_ROLE}`);
+    });
+  });
+
+  describe('Basic Audit Record', () => {
+    it('should allow an authorized auditor to add an audit record', async () => {
+      const { auditRegistry, erc721Metadata, owner, auditor1 } = await loadFixture(deployFixture);
+
+      // mint building NFT
+      await erc721Metadata.connect(owner)['mint(address,string)'](await owner.getAddress(), 'ipfs://building1');
+
+      const AUDITOR_ROLE = await auditRegistry.AUDITOR_ROLE();
+      await auditRegistry.connect(owner).addAuditor(await auditor1.getAddress());
+
+      // add audit record
+      await expect(auditRegistry.connect(auditor1).addAuditRecord(0, 'ipfs://audit1'))
+        .to.emit(auditRegistry, 'AuditRecordAdded')
+        .withArgs(
+          1, // audit recordId
+          0, // buildingId
+          await auditor1.getAddress(),
+          'ipfs://audit1',
+          anyValue // timestamp
+        );
+
+      const auditRecord = await auditRegistry.auditRecords(1);
+      expect(auditRecord.buildingId).to.equal(0);
+      expect(auditRecord.ipfsHash).to.equal('ipfs://audit1');
+      expect(auditRecord.revoked).to.be.false;
+    });
+  });
+});

--- a/test/audit/AuditRegistry.test.ts
+++ b/test/audit/AuditRegistry.test.ts
@@ -1,7 +1,6 @@
 import { expect, ethers } from '../setup';
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers';
-import { anyValue } from "@nomicfoundation/hardhat-chai-matchers/withArgs";
-
+import { anyValue } from '@nomicfoundation/hardhat-chai-matchers/withArgs';
 
 async function deployFixture() {
   const [owner, auditor1, auditor2] = await ethers.getSigners();
@@ -28,8 +27,8 @@ describe('AuditRegistry', () => {
     it('should deploy contracts successfully', async () => {
       const { erc721Metadata, auditRegistry } = await loadFixture(deployFixture);
 
-      expect(erc721Metadata.getAddress()).to.be.a('string');
-      expect(auditRegistry.getAddress()).to.be.a('string');
+      expect(await erc721Metadata.getAddress()).to.be.a('string');
+      expect(await auditRegistry.getAddress()).to.be.a('string');
     });
   });
 
@@ -47,14 +46,16 @@ describe('AuditRegistry', () => {
 
     it('should not allow non-admin to add an auditor', async () => {
       const { auditRegistry, auditor1, auditor2 } = await loadFixture(deployFixture);
-
+    
       const DEFAULT_ADMIN_ROLE = await auditRegistry.DEFAULT_ADMIN_ROLE();
-
+    
       await expect(
         auditRegistry.connect(auditor1).addAuditor(await auditor2.getAddress())
-      ).to.be.revertedWith(`AccessControl: account ${await auditor1.getAddress()} is missing role ${DEFAULT_ADMIN_ROLE}`);
+      ).to.be.revertedWithCustomError(auditRegistry, 'AccessControlUnauthorizedAccount').withArgs(
+        await auditor1.getAddress(),
+        DEFAULT_ADMIN_ROLE
+      );
     });
-  });
 
   describe('Basic Audit Record', () => {
     it('should allow an authorized auditor to add an audit record', async () => {
@@ -82,5 +83,6 @@ describe('AuditRegistry', () => {
       expect(auditRecord.ipfsHash).to.equal('ipfs://audit1');
       expect(auditRecord.revoked).to.be.false;
     });
+  });
   });
 });


### PR DESCRIPTION
## Description

This pull request introduces the AuditRegistry smart contract (changed name from "Assurance"), designed to manage audit records for building NFTs. The contract allows administrators to assign and remove auditor roles, while authorised auditors can add, update, and revoke audit records. Each record links a building NFT to an IPFS hash containing audit details.

Tests are currently only working when executed against the Hardhat network.


### Related Issues

* Closes #
