### PR TITLE
chore(ci): update CODEOWNERS default file value

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,7 @@
 ##### Global Protection Rule ######
 ###################################
 # NOTE: This rule is overriden by the more specific rules below. This is the catch-all rule for all files not covered by the more specific rules below.
-*                                               @hashgraph/devops-ci
+*                                               @hashgraph/unicsoft-hedera @hashgraph/developer-advocates
 
 ############################
 #####  Project Files  ######
@@ -43,7 +43,7 @@ hardhat.config.ts                               @hashgraph/unicsoft-hedera @hash
 
 # Protect the repository root files
 /README.md                                      @hashgraph/devops-ci @hashgraph/release-engineering-managers
-**/LICENSE                                      @hashgraph/devops-ci @hashgraph/release-engineering-managers
+**/LICENSE                                      @hashgraph/release-engineering-managers
 
 # CodeCov configuration
 **/codecov.yml                                  @hashgraph/devops-ci @hashgraph/release-engineering-managers


### PR DESCRIPTION
**Description**:

Update the CODEOWNERS file to remove devops-ci on the default file owner, replace with unicsoft-hedera and developer-advocates

**Related Issue(s)**:

Fixes #56

